### PR TITLE
feat: Implement multiple and custom pronoun sets with PlaceholderAPI …

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,16 @@ personal.
 
 I assume absolutely no responsibility if this plugin breaks anything - use at your own risk.
 
-### Planned feature list
+### Features
 
-- Players can set their pronouns individually
-- Players can have multiple pronoun sets
-- Custom player-defined custom pronouns / neopronouns support
-- Support for PlaceholderAPI with tools to properly form sentences including players' pronouns
-- Store players' pronouns in multiple places, including MySQL for network compatibility
-- Extensible through a developer API
-- Support for many platforms - Paper, Velocity. Sponge and BungeeCord support is planned.
+- **Individual Pronouns:** Players can set their pronouns to personalize their experience.
+- **Multiple Pronoun Sets:** Players can define and use multiple sets of pronouns (e.g., she/her and they/them).
+- **Custom Pronouns/Neopronouns:** Full support for player-defined custom pronouns with correct grammatical conjugation.
+- **PlaceholderAPI Support:** Extensive PlaceholderAPI integration, allowing for grammatically correct sentence construction using player pronouns, including support for multiple and custom sets with indexed access.
+- **Flexible Data Storage:** Options to store pronoun data, including MySQL for network-wide compatibility.
+- **Developer API:** Extensible API for other plugins to interact with pronoun data.
+- **Platform Support:** Currently supports Paper and Velocity. Sponge and BungeeCord support is planned.
+
 
 # Installation
 

--- a/docs/topics/Commands.md
+++ b/docs/topics/Commands.md
@@ -10,7 +10,7 @@
     : A specific command to show help for, otherwise lists all commands the player has access to.
 
 /pronouns get \[username]
-: Gets your or another player's pronouns.
+: Gets your or another player's pronouns. If multiple pronoun sets are defined, they will all be displayed (e.g., "She/Her, They/Them").
     
     **Arguments**
 
@@ -20,7 +20,16 @@
 
 
 /pronouns set \<pronouns> \[--player \<username>]
-: Sets your pronouns. See [](Setting-your-pronouns.md).
+: Sets your pronouns, overwriting any previously set. See [](Setting-your-pronouns.md) for a detailed guide.
+    You can specify multiple pronoun sets by separating them with a semicolon (`;`).
+    Custom pronouns can be defined using the format: `subjective/objective/possessiveAdjective/possessivePronoun/reflexive`. Add `:p` to the end for plural conjugation (e.g., `.../reflexive:p`).
+
+    **Examples:**
+    - `/pronouns set he/him`
+    - `/pronouns set she/her;they/them`
+    - `/pronouns set ze/zir/zir/zirs/zirself`
+    - `/pronouns set fae/faer/faer/faers/faerself:p`
+    - `/pronouns set he/him;ze/zir/zir/zirs/zirself:p`
 
     {style="medium"}
     Permission
@@ -30,13 +39,13 @@
 
     {style="narrow"}
     pronouns 
-    : The pronouns to set.
+    : The pronouns to set. Can be a single set or multiple sets separated by semicolons.
 
     player
     : A player to set pronouns for. or the sender if omitted. Requires permission <path>pronouns.set.other</path>.
 
 /pronouns clear \[--player \<username>]
-: Clears your pronouns.
+: Clears all your set pronouns. This effectively sets your pronouns to "Unset".
 
     {style="medium"}
     Permission

--- a/docs/topics/Placeholders.md
+++ b/docs/topics/Placeholders.md
@@ -8,22 +8,33 @@ Placeholders are available through <a href="https://www.spigotmc.org/resources/p
 by HelpChat.
 </p>
 
+Many placeholders now support an optional numeric index to access specific pronoun sets when a player has defined multiple. This index is 1-based. For example, `_1` refers to the first set, `_2` to the second, and so on. If no index is provided, these placeholders will default to using the player's *first* pronoun set. If an invalid index is used (e.g., too high, not a number), the placeholder will generally return an empty string.
+
 <!-- FIXME: switch this to a deflist, blocked by wrs-1142
     switcher-key is ignored in deflists https://youtrack.jetbrains.com/issue/WRS-1142
     -->
 
-| Paper                          | Description                                                              | Examples                                     |
-|--------------------------------|--------------------------------------------------------------------------|----------------------------------------------|
-| `%\pronouns_pronouns%`         | A player's pronouns in display form, or **Unset** if not set.            | **She/Her**, **Unset**                       |
-| `%\pronouns_subjective%`       | The subjective pronoun.                                                  | **they**                                     |
-| `%\pronouns_objective%`        | The objective pronoun.                                                   | **them**                                     |
-| `%\pronouns_possessiveadj%`    | The possessive adjective.                                                | **theirs**                                   |
-| `%\pronouns_possessive%`       | The possessive pronoun.                                                  | **their**                                    |
-| `%\pronouns_reflexive%`        | The reflexive pronoun.                                                   | **themselves**                               |
-| `%\pronouns_all%`              | The first pronoun set in full form.                                      | **they/them/theirs/their/themselves:p**      |
-| `%\pronouns_verb_<verb>%`      | Conjugates \<verb>.                                                      | (he) **is**, (they) **have**, (she) **goes** |
-| `%\pronouns_conj_<sing>_<pl>%` | If the player's first pronoun set is singular, \<sing>, otherwise \<pl>. |                                              |
+| Paper                                              | Description                                                                                                | Examples                                                                    |
+|----------------------------------------------------|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| `%\pronouns_pronouns%`                             | A player's pronouns in display form (e.g., "She/Her, They/Them"), or **Unset** if not set.                  | **She/Her, They/Them**; **Unset**                                           |
+| `%\pronouns_subjective%`<br>`%\pronouns_subjective_<index>%` | The subjective pronoun. Uses 1st set if no index.                                                        | **they**; `%p_subjective_2%` -> **he**                                      |
+| `%\pronouns_objective%`<br>`%\pronouns_objective_<index>%` | The objective pronoun. Uses 1st set if no index.                                                         | **them**; `%p_objective_2%` -> **him**                                      |
+| `%\pronouns_possessiveadj%`<br>`%\pronouns_possessiveadj_<index>%` | The possessive adjective. Uses 1st set if no index.                                                  | **their**; `%p_possessiveadj_2%` -> **his**                                 |
+| `%\pronouns_possessive%`<br>`%\pronouns_possessive_<index>%` | The possessive pronoun. Uses 1st set if no index.                                                      | **theirs**; `%p_possessive_2%` -> **his**                                   |
+| `%\pronouns_reflexive%`<br>`%\pronouns_reflexive_<index>%` | The reflexive pronoun. Uses 1st set if no index.                                                       | **themselves**; `%p_reflexive_2%` -> **himself**                            |
+| `%\pronouns_all%`                                  | All pronoun sets in full `s/o/pa/p/r(:p)` form, joined by "; ".                                           | **she/her/her/hers/herself; they/them/their/theirs/themselves:p**           |
+| `%\pronouns_verb_<verb>%`<br>`%\pronouns_verb_<index>_<verb>%` | Conjugates \<verb> based on the plurality of the selected set. Uses 1st set if no index.                   | (he) **is**; `%p_verb_2_BE%` -> **are** (if 2nd set is plural)             |
+| `%\pronouns_conj_<sing>_<pl>%`<br>`%\pronouns_conj_<index>_<sing>_<pl>%` | If the selected set is singular, outputs \<sing>, otherwise \<pl>. Uses 1st set if no index.             | `%p_conj_1_has_have%` -> **has** (if 1st set is singular)                   |
 
+*(Shortened example: `%p_subjective_2%` is equivalent to `%pronouns_subjective_2%`)*
+
+## Using Indexed Placeholders in Sentences
+
+Here are a few examples of how you might use indexed placeholders:
+- "Player uses %pronouns_subjective_1%/%pronouns_objective_1% and sometimes %pronouns_subjective_2%/%pronouns_objective_2%."
+  - *Output could be: "Player uses she/her and sometimes ey/em."*
+- "For their first set, %pronouns_subjective_1% %pronouns_verb_1_BE% happy. For their second, %pronouns_subjective_2% %pronouns_verb_2_BE% also happy."
+  - *Output could be: "For their first set, she is happy. For their second, ey are also happy."*
 
 ## Modifiers
 

--- a/docs/topics/Pronoun-set-format.md
+++ b/docs/topics/Pronoun-set-format.md
@@ -2,25 +2,38 @@
 
 <include from="snippets.topic" element-id="grammar"/>
 
-The English language is kinda hard for computers to deal with, so to properly represent your pronouns 
-we need to do it in a certain format.
+The English language has a variety of pronouns, and to ensure ProNouns can use them correctly, especially for custom and neopronouns, they need to be defined in a specific format. This format is used when you set custom pronouns with the `/pronouns set` command.
 
-Recall that there are five pronouns we need to consider:
+A pronoun set is defined by five core components, separated by slashes (`/`):
 
-- personal subjective
-- personal objective 
-- possessive
-- possessive adjective
-- reflexive
+1.  **Subjective:** The pronoun used when it's the subject of a verb.
+    *(e.g., **he** runs, **she** sings, **ze** laughs)*
+2.  **Objective:** The pronoun used when it's the object of a verb or preposition.
+    *(e.g., I saw **him**, give it to **her**, look at **zir**)*
+3.  **Possessive Adjective:** The determiner used to indicate possession before a noun.
+    *(e.g., **his** book, **her** idea, **zir** project)*
+4.  **Possessive Pronoun:** The pronoun used to indicate possession that can stand alone.
+    *(e.g., the book is **his**, the idea is **hers**, the project is **zirs**)*
+5.  **Reflexive:** The pronoun used when the subject and object of a verb are the same.
+    *(e.g., he helps **himself**, she trusts **herself**, ze knows **zirself**)*
 
-We also need to know whether it's singular or plural.
+Additionally, we need to specify whether the pronoun set uses singular or plural verb conjugations.
 
-ProNouns stores all these pronouns separated by a slash, with the suffix `:p` if it's plural:
+**The Format String:**
 
-- `subjective/objective/possessive-adjective/possessive/reflexive` for singular sets
-- `subjective/objective/possessive-adjective/possessive/reflexive:p` for plural sets
+ProNouns expects these five components in the following order, with an optional `:p` suffix for plural conjugation:
 
-Some examples (these are all builtin, you shouldn't ever need to use these):
+-   `subjective/objective/possessiveAdjective/possessivePronoun/reflexive` (for singular conjugation, e.g., "ze is")
+-   `subjective/objective/possessiveAdjective/possessivePronoun/reflexive:p` (for plural conjugation, e.g., "ze are")
 
-- `he/him/his/his/himself`
-- `they/them/their/theirs/themselves:p`
+**Examples:**
+
+-   **Predefined "he/him" (singular):** `he/him/his/his/himself`
+-   **Predefined "they/them" (plural):** `they/them/their/theirs/themselves:p`
+-   **Custom "ze/zir" (singular):** `ze/zir/zir/zirs/zirself`
+-   **Custom "fae/faer" (plural):** `fae/faer/faer/faers/faerself:p`
+
+When using the `/pronouns set` command, you provide a string in this format if you are defining a custom pronoun set. For example:
+`/pronouns set ze/zir/zir/zirs/zirself;fae/faer/faer/faers/faerself:p`
+
+This page serves as a technical reference for the format. For a step-by-step guide on setting your pronouns, including custom ones, please see [Setting Your Pronouns](Setting-your-pronouns.md).

--- a/docs/topics/Setting-your-pronouns.md
+++ b/docs/topics/Setting-your-pronouns.md
@@ -1,19 +1,68 @@
-# Setting your pronouns
+# Setting Your Pronouns
 
-To set your pronouns, you can use the `/pronouns set <pronouns>` command.
-Generally speaking, you can put anything in here - it's pretty good at guessing what you mean. 
+You can set your pronouns using the `/pronouns set <pronouns>` command. This command allows you to define one or more pronoun sets, including predefined options, special sets, and custom neopronouns. When you use this command, it will overwrite any pronouns you currently have set.
 
-Here are the options:
+## Basic Usage
 
-- you can set a single set, for example `/pn set she` or `/pn set he/him`
-- you can set multiple sets, for example `/pn set she/they` or `/pn set they he`
-- you can use the special values `/pn set any` or `/pn set ask`
-- you can use neopronouns - see below
+For common pronouns, you can often use short forms:
 
-## Neopronouns
+-   `/pronouns set he/him`
+-   `/pronouns set she/her`
+-   `/pronouns set they/them`
 
-The plugin supports using neopronouns - how you do it depends on the way the server you're playing on is configured.
+You can also use special values:
 
-1. First of all, try setting it normally as per the first example on the page.
-2. If that doesn't work, you'll need to figure out what your pronouns are in [the plugin's format](Pronoun-set-format.md).
-You can do this using [the tool on my website](https://lucypoulton.net/pn) - it'll give you a command to copy-paste.
+-   `/pronouns set any` (indicates any pronouns are fine)
+-   `/pronouns set ask` (indicates people should ask for your pronouns)
+-   `/pronouns set unset` (clears your pronouns, same as `/pronouns clear`)
+
+## Using Multiple Pronoun Sets
+
+If you use more than one set of pronouns, you can define them all by separating each set with a semicolon (`;`).
+
+**Examples:**
+
+-   To set "she/her" and "they/them":
+    `/pronouns set she/her;they/them`
+-   To set "he/him" and "they/them":
+    `/pronouns set he/him;they/them`
+
+The order you list them in will be preserved in some contexts.
+
+## Defining Custom Pronouns (Neopronouns)
+
+You can define your own custom pronouns (often called neopronouns) using a specific five-part format, separated by slashes (`/`):
+
+`subjective/objective/possessiveAdjective/possessivePronoun/reflexive`
+
+**Understanding the Parts:**
+
+1.  **Subjective:** The pronoun used as the subject of a sentence (e.g., **he** is happy, **she** is happy, **they** are happy).
+2.  **Objective:** The pronoun used as the object of a sentence (e.g., I like **him**, I like **her**, I like **them**).
+3.  **Possessive Adjective:** The pronoun that shows possession before a noun (e.g., **his** cat, **her** cat, **their** cat).
+4.  **Possessive Pronoun:** The pronoun that shows possession and stands alone (e.g., the cat is **his**, the cat is **hers**, the cat is **theirs**).
+5.  **Reflexive:** The pronoun used when the subject and object are the same (e.g., he likes **himself**, she likes **herself**, they like **themselves**).
+
+**Plural Conjugation (for verbs like "is/are"):**
+
+By default, custom pronouns will use singular verb conjugation (e.g., "ze **is**"). If your custom pronouns should use plural conjugation (e.g., "fae **are**"), add `:p` to the end of the reflexive part.
+
+**Examples of Setting Custom Pronouns:**
+
+-   For "ze/zir/zir/zirs/zirself" (singular conjugation):
+    `/pronouns set ze/zir/zir/zirs/zirself`
+
+-   For "fae/faer/faer/faers/faerself" but with plural conjugation (e.g., "fae are"):
+    `/pronouns set fae/faer/faer/faers/faerself:p`
+
+-   For "ey/em/eir/eirs/emself" (singular conjugation):
+    `/pronouns set ey/em/eir/eirs/emself`
+
+**Combining Custom and Predefined Pronouns:**
+
+You can mix custom pronouns and predefined pronouns using the semicolon (`;`) delimiter:
+
+-   `/pronouns set he/him;ze/zir/zir/zirs/zirself`
+-   `/pronouns set she/her;fae/faer/faer/faers/faerself:p;they/them`
+
+For a more detailed technical breakdown of the pronoun set format, see the [Pronoun Set Format](Pronoun-set-format.md) page.

--- a/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/cmd/ClearCommand.java
+++ b/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/cmd/ClearCommand.java
@@ -30,7 +30,7 @@ public class ClearCommand implements ProNounsCommand {
             return;
         }
 
-        plugin.store().set(player.uuid().get(), List.of());
+        plugin.store().set(player.uuid().get(), net.lucypoulton.pronouns.api.PronounStore.UNSET_LIST);
         commandSender.sendMessage(
                 plugin.formatter().translated(
                         "pronouns.command.clear." + (sender.isNotSender() ? "other" : "self"),

--- a/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/cmd/GetCommand.java
+++ b/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/cmd/GetCommand.java
@@ -27,7 +27,8 @@ public class GetCommand implements ProNounsCommand {
             return;
         }
         final var pronouns = plugin.store().sets(targetPlayer.uuid().get());
-        if (pronouns.size() == 1 && pronouns.get(0).equals(PronounSet.Builtins.UNSET)) {
+        // Check if the list is empty or explicitly UNSET_LIST
+        if (pronouns.isEmpty() || pronouns.equals(net.lucypoulton.pronouns.api.PronounStore.UNSET_LIST)) {
             sender.sendMessage(
                     f.translated("pronouns.command.get.unset." + (targetCommandSender.isNotSender() ? "other" : "self"),
                             targetPlayer.name()));

--- a/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/cmd/SetCommand.java
+++ b/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/cmd/SetCommand.java
@@ -29,20 +29,28 @@ public class SetCommand implements ProNounsCommand {
             sender.sendMessage(f.translated("pronouns.command.noPlayer"));
             return;
         }
+
+        final List<PronounSet> pronouns;
         try {
-            final var pronouns = plugin.parser().parse(value);
-            plugin.store().set(player.uuid().get(), pronouns);
-            sender.sendMessage(
-                    f.translated("pronouns.command.set." + (target.isNotSender() ? "other" : "self"),
-                            PronounSet.format(pronouns),
-                            player.name()
-                    )
-            );
+            pronouns = plugin.parser().parse(value);
+        } catch (Exception e) {
+            // Catch any unexpected parsing errors, though PronounParser is expected to return empty list for bad user input
+            plugin.platform().logger().warning("Pronoun parsing unexpectedly failed for input '" + value + "': " + e.getMessage());
+            sender.sendMessage(f.translated("pronouns.command.set.parseError", value));
             return;
-        } catch (IllegalArgumentException ignored) {
         }
+
+        if (pronouns.isEmpty()) {
+            sender.sendMessage(f.translated("pronouns.command.set.badSet", value));
+            return;
+        }
+
+        plugin.store().set(player.uuid().get(), pronouns);
         sender.sendMessage(
-                f.translated("pronouns.command.set.badSet", value)
+                f.translated("pronouns.command.set." + (target.isNotSender() ? "other" : "self"),
+                        PronounSet.format(pronouns),
+                        player.name()
+                )
         );
     }
 

--- a/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/placeholder/Placeholders.java
+++ b/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/placeholder/Placeholders.java
@@ -6,26 +6,83 @@ import net.lucypoulton.pronouns.common.ProNouns;
 import net.lucypoulton.pronouns.common.placeholder.Placeholder.Result;
 import net.lucypoulton.pronouns.common.util.EnumUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class Placeholders {
 
-    private static String applyModifiers(List<PronounSet> set, String value, String[] modifiers) {
+    @FunctionalInterface
+    private interface TriFunction<A, B, C, R> {
+        R apply(A a, B b, C c);
+    }
+
+    private static class ParsedArgs {
+        final List<String> coreArgs = new ArrayList<>();
+        Optional<Integer> index = Optional.empty();
+        final List<String> modifierStrings = new ArrayList<>();
+        boolean indexExplicitlyPresent = false;
+
+        ParsedArgs(String fullArgString) {
+            String[] parts = fullArgString.split("[_ ]");
+            Set<String> knownModifiers = Set.of("uppercase", "lowercase", "capital", "nounset");
+            boolean foundIndexInThisPass = false;
+
+            for (String part : parts) {
+                if (part.isEmpty()) continue;
+
+                if (!foundIndexInThisPass) {
+                    try {
+                        this.index = Optional.of(Integer.parseInt(part));
+                        this.indexExplicitlyPresent = true;
+                        foundIndexInThisPass = true;
+                        continue;
+                    } catch (NumberFormatException e) {
+                        // Not an index
+                    }
+                }
+
+                if (knownModifiers.contains(part.toLowerCase(Locale.ROOT))) {
+                    this.modifierStrings.add(part.toLowerCase(Locale.ROOT));
+                } else {
+                    this.coreArgs.add(part);
+                }
+            }
+        }
+    }
+
+    private static String applyModifiers(PronounSet selectedSet, String value, List<String> modifierStrings) {
         var out = value;
-        for (final String mod : modifiers) {
-            out = switch (mod.toLowerCase(Locale.ROOT)) {
+
+        // Handle nounset first: if no set is selected (e.g. invalid index) and nounset is a modifier, result is empty.
+        // Also, if selectedSet is null because user has no pronouns, nounset should also make it empty.
+        if (modifierStrings.contains("nounset")) {
+            if (selectedSet == null || selectedSet.equals(PronounSet.Builtins.UNSET)) {
+                return "";
+            }
+        }
+
+        // If no set was successfully selected (e.g., invalid index) and we already returned for nounset,
+        // other modifiers should not apply to an empty string that indicates an error.
+        // However, if selectedSet is null because the user genuinely has no pronouns (userAllSets was empty),
+        // then `value` would likely be "" already from the placeholder logic.
+        if (selectedSet == null && value.isEmpty()) { // Typically means invalid index caused placeholder to return ""
+             return ""; // Don't apply further modifiers like uppercase to an error indicator.
+        }
+
+
+        for (final String mod : modifierStrings) {
+            out = switch (mod) {
                 case "uppercase" -> out.toUpperCase(Locale.ROOT);
                 case "lowercase" -> out.toLowerCase(Locale.ROOT);
-                case "capital" -> switch (out.length()) {
-                    case 0 -> out;
-                    case 1 -> out.toUpperCase(Locale.ROOT);
-                    default -> out.substring(0, 1).toUpperCase(Locale.ROOT) + out.substring(1).toLowerCase(Locale.ROOT);
-                };
-                case "nounset" -> set.get(0).equals(PronounSet.Builtins.UNSET) ? "" : out;
+                case "capital" -> out.isEmpty() ? "" :
+                        (out.length() == 1 ? out.toUpperCase(Locale.ROOT) :
+                                out.substring(0, 1).toUpperCase(Locale.ROOT) + out.substring(1).toLowerCase(Locale.ROOT));
+                case "nounset" -> { /* Already handled */ yield out; }
                 default -> out;
             };
         }
@@ -34,40 +91,103 @@ public class Placeholders {
 
     private final ProNouns plugin;
 
+    // Updated placeholder definitions using the new forPronoun structure
+
     public final Placeholder subjective = forPronoun("subjective", PronounSet::subjective);
     public final Placeholder objective = forPronoun("objective", PronounSet::objective);
     public final Placeholder possessiveAdj = forPronoun("possessiveadj", PronounSet::possessiveAdj);
     public final Placeholder possessive = forPronoun("possessive", PronounSet::possessive);
     public final Placeholder reflexive = forPronoun("reflexive", PronounSet::reflexive);
 
-    public final Placeholder pronouns = forPronoun("pronouns", (sets, args) -> Result.of(PronounSet.format(sets)));
-    public final Placeholder all = forPronoun("all", PronounSet::toFullString);
-
-    public final Placeholder verb = forPronoun("verb", (set, value) -> {
-        final var verb = EnumUtil.getByName(Conjugator.class, value[0]);
-        return verb.map(conjugator -> Result.of(conjugator.conjugate(set.get(0).plural())))
-                .orElseGet(() -> Result.fail("Unknown verb " + value[0]));
+    public final Placeholder pronouns = forPronoun("pronouns", (userAllSets, parsedArgs, selectedSet) -> {
+        if (userAllSets.isEmpty()) return Result.of("");
+        return Result.of(PronounSet.format(userAllSets));
     });
 
-    public final Placeholder conjugate = forPronoun("conj", (set, value) -> {
-        if (value.length == 1) return Result.fail("Missing options for conjugation");
-        return Result.of(value[set.get(0).plural() ? 1 : 0]);
+    public final Placeholder all = forPronoun("all", (userAllSets, parsedArgs, selectedSet) -> {
+        if (userAllSets.isEmpty()) return Result.of("");
+        return Result.of(
+                userAllSets.stream()
+                        .map(PronounSet::toFullString)
+                        .collect(Collectors.joining("; "))
+        );
     });
 
-    private Placeholder forPronoun(String name, BiFunction<List<PronounSet>, String[], Result> value) {
-        return new Placeholder(name, ((sender, s) -> {
+    public final Placeholder verb = forPronoun("verb", (userAllSets, parsedArgs, selectedSet) -> {
+        if (selectedSet == null) return Result.of(""); // Invalid index or no pronouns for user
+        if (parsedArgs.coreArgs.isEmpty()) return Result.fail("Missing verb type for %pronouns_verb%");
+        String verbName = parsedArgs.coreArgs.get(0);
+        final var verbEnum = EnumUtil.getByName(Conjugator.class, verbName);
+        return verbEnum.map(conjugator -> Result.of(conjugator.conjugate(selectedSet.plural())))
+                .orElseGet(() -> Result.fail("Unknown verb " + verbName + " for %pronouns_verb%"));
+    });
+
+    public final Placeholder conjugate = forPronoun("conj", (userAllSets, parsedArgs, selectedSet) -> {
+        if (selectedSet == null) return Result.of(""); // Invalid index or no pronouns for user
+        if (parsedArgs.coreArgs.size() < 2) return Result.fail("Missing options for %pronouns_conj%");
+        return Result.of(parsedArgs.coreArgs.get(selectedSet.plural() ? 1 : 0));
+    });
+
+
+    private Placeholder forPronoun(String name, TriFunction<List<PronounSet>, ParsedArgs, PronounSet, Result> valueProducer) {
+        return new Placeholder(name, (sender, s_args) -> {
             if (sender.uuid().isEmpty()) return Result.fail("No player");
-            final var sets = plugin.store().sets(sender.uuid().get());
-            final var split = s.split("[_ ]");
-            final var out = value.apply(sets, split);
-            if (out.success()) return Result.of(applyModifiers(sets, out.message(), split));
-            return out;
-        }));
+            final List<PronounSet> userAllSets = plugin.store().sets(sender.uuid().get());
+            final ParsedArgs parsedArgs = new ParsedArgs(s_args);
+
+            PronounSet selectedSet = null;
+            boolean selectionFailedDueToInvalidIndex = false;
+
+            if (userAllSets.isEmpty()) {
+                if (parsedArgs.indexExplicitlyPresent) {
+                    selectionFailedDueToInvalidIndex = true;
+                }
+                // selectedSet remains null
+            } else {
+                if (parsedArgs.index.isPresent()) {
+                    int idx = parsedArgs.index.get();
+                    if (idx > 0 && idx <= userAllSets.size()) {
+                        selectedSet = userAllSets.get(idx - 1);
+                    } else {
+                        selectionFailedDueToInvalidIndex = true;
+                        // selectedSet remains null
+                    }
+                } else {
+                    selectedSet = userAllSets.get(0); // Default to first if no index
+                }
+            }
+
+            if (selectionFailedDueToInvalidIndex) {
+                // If an explicit, but invalid, index was given, return empty string after applying modifiers.
+                // This allows "nounset" to still make it empty, or other modifiers if needed (though usually not on error).
+                return Result.of(applyModifiers(null, "", parsedArgs.modifierStrings));
+            }
+
+            Result producedResult = valueProducer.apply(userAllSets, parsedArgs, selectedSet);
+
+            if (producedResult.success()) {
+                return Result.of(applyModifiers(selectedSet, producedResult.message(), parsedArgs.modifierStrings));
+            }
+            return producedResult; // Failures (e.g. unknown verb) are returned directly
+        });
     }
 
-    private Placeholder forPronoun(String name, Function<PronounSet, String> value) {
-        return forPronoun(name, (set, str) -> Result.of(value.apply(set.get(0))));
+    private Placeholder forPronoun(String name, Function<PronounSet, String> singleSetToString) {
+        return forPronoun(name, (userAllSets, parsedArgs, selectedSet) -> {
+            if (selectedSet == null) {
+                // This case is hit if:
+                // 1. User has no pronouns (userAllSets is empty) and no specific index was requested.
+                // 2. An invalid index was specified (handled by selectionFailedDueToInvalidIndex in the calling forPronoun).
+                //    In this case, the calling forPronoun already returned an empty modified string.
+                //    So, if we reach here and selectedSet is null, it's typically case 1.
+                // For single form placeholders, if no set is applicable (either no pronouns, or invalid index already handled),
+                // outputting empty string is appropriate.
+                return Result.of("");
+            }
+            return Result.of(singleSetToString.apply(selectedSet));
+        });
     }
+
 
     public Placeholders(ProNouns plugin) {
         this.plugin = plugin;

--- a/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/store/FilePronounStore.java
+++ b/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/store/FilePronounStore.java
@@ -42,7 +42,7 @@ public class FilePronounStore implements PronounStore {
         sets.forEach(((uuid, pronounSets) -> props.put(uuid.toString(),
                 pronounSets.stream()
                         .map(PronounSet::toFullString)
-                        .collect(Collectors.joining("/"))
+                        .collect(Collectors.joining(";")) // Changed delimiter to semicolon
         )));
         try (final var outStream = Files.newOutputStream(path)) {
             props.store(outStream, header);
@@ -83,5 +83,45 @@ public class FilePronounStore implements PronounStore {
     @Override
     public Map<UUID, List<PronounSet>> dump() {
         return Collections.unmodifiableMap(sets);
+    }
+
+    @Override
+    public void addPronouns(UUID player, @NotNull List<PronounSet> pronounsToAdd) {
+        if (pronounsToAdd.isEmpty()) {
+            return;
+        }
+        final List<PronounSet> currentSets = new ArrayList<>(sets(player));
+
+        if (currentSets.size() == 1 && currentSets.get(0).equals(PronounSet.Builtins.UNSET)) {
+            if (pronounsToAdd.size() == 1 && pronounsToAdd.get(0).equals(PronounSet.Builtins.UNSET)) {
+                return;
+            }
+            currentSets.clear();
+        }
+
+        for (final PronounSet toAdd : pronounsToAdd) {
+            if (!currentSets.contains(toAdd)) {
+                currentSets.add(toAdd);
+            }
+        }
+        set(player, currentSets); // set already calls save
+    }
+
+    @Override
+    public void removePronouns(UUID player, @NotNull List<PronounSet> pronounsToRemove) {
+        if (pronounsToRemove.isEmpty()) {
+            return;
+        }
+        final List<PronounSet> currentSets = new ArrayList<>(sets(player));
+
+        if (currentSets.size() == 1 && currentSets.get(0).equals(PronounSet.Builtins.UNSET)) {
+            if (pronounsToRemove.contains(PronounSet.Builtins.UNSET)) {
+                set(player, Collections.emptyList()); // Clears the entry and saves
+            }
+            return;
+        }
+
+        currentSets.removeAll(pronounsToRemove);
+        set(player, currentSets); // set already calls save
     }
 }

--- a/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/store/InMemoryPronounStore.java
+++ b/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/store/InMemoryPronounStore.java
@@ -36,6 +36,51 @@ public class InMemoryPronounStore implements PronounStore {
     }
 
     @Override
+    public void addPronouns(UUID player, @NotNull List<PronounSet> pronounsToAdd) {
+        if (pronounsToAdd.isEmpty()) {
+            return;
+        }
+        final List<PronounSet> currentSets = new ArrayList<>(sets(player));
+
+        // If current is UNSET, replace with new pronouns if new ones are not UNSET.
+        // If pronounsToAdd contains UNSET and currentSets is UNSET, do nothing.
+        if (currentSets.size() == 1 && currentSets.get(0).equals(PronounSet.Builtins.UNSET)) {
+            if (pronounsToAdd.size() == 1 && pronounsToAdd.get(0).equals(PronounSet.Builtins.UNSET)) {
+                return; // Adding UNSET to UNSET does nothing
+            }
+            // If adding actual pronouns to an UNSET record, treat currentSets as empty before adding.
+            // unless pronounsToAdd is also UNSET (already handled)
+            currentSets.clear();
+        }
+
+        for (final PronounSet toAdd : pronounsToAdd) {
+            if (!currentSets.contains(toAdd)) {
+                currentSets.add(toAdd);
+            }
+        }
+        set(player, currentSets);
+    }
+
+    @Override
+    public void removePronouns(UUID player, @NotNull List<PronounSet> pronounsToRemove) {
+        if (pronounsToRemove.isEmpty()) {
+            return;
+        }
+        final List<PronounSet> currentSets = new ArrayList<>(sets(player));
+
+        // If current is UNSET, there's nothing to remove unless removing UNSET itself
+        if (currentSets.size() == 1 && currentSets.get(0).equals(PronounSet.Builtins.UNSET)) {
+            if (pronounsToRemove.contains(PronounSet.Builtins.UNSET)) {
+                set(player, Collections.emptyList()); // Clears the entry
+            }
+            return;
+        }
+
+        currentSets.removeAll(pronounsToRemove);
+        set(player, currentSets);
+    }
+
+    @Override
     public Map<UUID, List<PronounSet>> dump() {
         return Collections.unmodifiableMap(storage);
     }

--- a/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/store/MySqlPronounStore.java
+++ b/pronouns-common/src/main/java/net/lucypoulton/pronouns/common/store/MySqlPronounStore.java
@@ -74,7 +74,7 @@ public class MySqlPronounStore implements CachedPronounStore, AutoCloseable {
             }
             final var stmt = con.prepareStatement("REPLACE INTO pronouns (player, pronouns, last_updated_from) VALUES (?, ?, ?)");
             stmt.setBytes(1, UuidUtil.toBytes(uuid));
-            stmt.setString(2, parser.toString(sets));
+            stmt.setString(2, sets.stream().map(PronounSet::toFullString).collect(java.util.stream.Collectors.joining(";")));
             stmt.setString(3, plugin.meta().identifier());
             stmt.execute();
         } catch (SQLException e) {
@@ -87,7 +87,7 @@ public class MySqlPronounStore implements CachedPronounStore, AutoCloseable {
             final var stmt = con.prepareStatement("REPLACE INTO pronouns (player, pronouns, last_updated_from) VALUES (?, ?, ?)");
             for (final var entry : sets.entrySet()) {
                 stmt.setBytes(1, UuidUtil.toBytes(entry.getKey()));
-                stmt.setString(2, parser.toString(entry.getValue()));
+                stmt.setString(2, entry.getValue().stream().map(PronounSet::toFullString).collect(java.util.stream.Collectors.joining(";")));
                 stmt.setString(3, plugin.meta().identifier());
                 stmt.addBatch();
             }
@@ -130,6 +130,65 @@ public class MySqlPronounStore implements CachedPronounStore, AutoCloseable {
             lastTimestamp = Instant.now();
         } catch (Exception e) {
             plugin.platform().logger().error("Failed to update pronoun cache from MySQL: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void addPronouns(UUID player, @NotNull List<PronounSet> pronounsToAdd) {
+        if (pronounsToAdd.isEmpty()) {
+            return;
+        }
+        final List<PronounSet> currentSets = new ArrayList<>(sets(player));
+
+        if (currentSets.size() == 1 && currentSets.get(0).equals(PronounSet.Builtins.UNSET)) {
+            if (pronounsToAdd.size() == 1 && pronounsToAdd.get(0).equals(PronounSet.Builtins.UNSET)) {
+                return;
+            }
+            currentSets.clear();
+        }
+
+        for (final PronounSet toAdd : pronounsToAdd) {
+            if (!currentSets.contains(toAdd)) {
+                currentSets.add(toAdd);
+            }
+        }
+        // Update cache immediately
+        if (currentSets.isEmpty()) {
+            cache.remove(player);
+        } else {
+            cache.put(player, currentSets);
+        }
+        // Asynchronously push to database
+        final List<PronounSet> setsToPush = List.copyOf(currentSets); // Make a copy for the async task
+        plugin.executorService().submit(() -> push(player, setsToPush));
+    }
+
+    @Override
+    public void removePronouns(UUID player, @NotNull List<PronounSet> pronounsToRemove) {
+        if (pronounsToRemove.isEmpty()) {
+            return;
+        }
+        final List<PronounSet> currentSets = new ArrayList<>(sets(player));
+
+        if (currentSets.size() == 1 && currentSets.get(0).equals(PronounSet.Builtins.UNSET)) {
+            if (pronounsToRemove.contains(PronounSet.Builtins.UNSET)) {
+                cache.remove(player);
+                plugin.executorService().submit(() -> push(player, Collections.emptyList()));
+            }
+            return;
+        }
+
+        boolean changed = currentSets.removeAll(pronounsToRemove);
+        if (changed) {
+            // Update cache immediately
+            if (currentSets.isEmpty()) {
+                cache.remove(player);
+            } else {
+                cache.put(player, currentSets);
+            }
+            // Asynchronously push to database
+            final List<PronounSet> setsToPush = List.copyOf(currentSets); // Make a copy for the async task
+            plugin.executorService().submit(() -> push(player, setsToPush));
         }
     }
 

--- a/pronouns-common/src/test/java/net/lucypoulton/pronouns/common/store/FilePronounStoreTest.java
+++ b/pronouns-common/src/test/java/net/lucypoulton/pronouns/common/store/FilePronounStoreTest.java
@@ -1,0 +1,234 @@
+package net.lucypoulton.pronouns.common.store;
+
+import net.lucypoulton.pronouns.api.PronounParser;
+import net.lucypoulton.pronouns.api.PronounStore;
+import net.lucypoulton.pronouns.api.set.PronounSet;
+import net.lucypoulton.pronouns.common.ProNouns;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+public class FilePronounStoreTest {
+
+    private FilePronounStore store;
+    @TempDir
+    Path tempDir;
+    private Path storePath;
+
+    private final UUID testUuid1 = UUID.randomUUID();
+    private final UUID testUuid2 = UUID.randomUUID();
+
+    private final PronounSet HE = PronounSet.Builtins.HE;
+    private final PronounSet SHE = PronounSet.Builtins.SHE;
+    private final PronounSet THEY = PronounSet.Builtins.THEY;
+    private final PronounSet UNSET = PronounSet.Builtins.UNSET;
+    private final List<PronounSet> UNSET_LIST = PronounStore.UNSET_LIST;
+
+    // Mock ProNouns plugin and its components as FilePronounStore requires it
+    private ProNouns mockPlugin;
+    private ExecutorService executorService; // For save operations
+
+    @BeforeEach
+    void setUp() {
+        storePath = tempDir.resolve("test-pronouns.properties");
+        // Mock ProNouns and its ExecutorService for save operations
+        mockPlugin = Mockito.mock(ProNouns.class);
+        executorService = Executors.newSingleThreadExecutor(); // Use a real executor for testing save/load
+        Mockito.when(mockPlugin.executorService()).thenReturn(executorService);
+        // FilePronounStore uses a static parser, so no need to mock that via plugin
+        store = new FilePronounStore(mockPlugin, tempDir); // Path to directory, file is named inside
+    }
+
+    // Helper to ensure save operations complete before assertion by new instances
+    private void waitForSave() {
+        //This is a bit of a hack for testing. In real usage, saves are async.
+        //Forcing the executor to complete submitted tasks.
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(500, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        // Reinitialize for next test operations if needed, or ensure each test has its own executor management
+        executorService = Executors.newSingleThreadExecutor();
+        Mockito.when(mockPlugin.executorService()).thenReturn(executorService);
+    }
+
+
+    @Test
+    @DisplayName("New store returns UNSET_LIST for unknown UUID")
+    void newStoreReturnsUnset() {
+        assertEquals(UNSET_LIST, store.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Set and get a single pronoun set")
+    void setAndGetSinglePronoun() {
+        List<PronounSet> pronouns = List.of(SHE);
+        store.set(testUuid1, pronouns);
+        assertEquals(pronouns, store.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Set and get multiple pronoun sets")
+    void setAndGetMultiplePronouns() {
+        List<PronounSet> pronouns = List.of(SHE, THEY);
+        store.set(testUuid1, pronouns);
+        assertIterableEquals(pronouns, store.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Persistence: Data survives store recreation")
+    void dataSurvivesRecreation() {
+        List<PronounSet> pronouns = List.of(HE, THEY);
+        store.set(testUuid1, pronouns);
+        waitForSave();
+
+        // New store instance loading from the same file path
+        FilePronounStore newStore = new FilePronounStore(mockPlugin, tempDir);
+        assertIterableEquals(pronouns, newStore.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Persistence: File content check")
+    void fileContentCheck() throws IOException {
+        // Use a known parser for expected string. FilePronounStore uses a static internal one.
+        PronounParser parserForFileCheck = new PronounParser(PronounSet.builtins);
+
+        List<PronounSet> pronouns1 = List.of(SHE, THEY);
+        store.set(testUuid1, pronouns1);
+
+        List<PronounSet> pronouns2 = List.of(HE);
+        store.set(testUuid2, pronouns2);
+        waitForSave();
+
+        List<String> lines = Files.readAllLines(storePath.resolve("pronouns-store.properties"));
+        // Remove comments and blank lines
+        lines.removeIf(line -> line.startsWith("#") || line.trim().isEmpty());
+
+        String expectedLine1 = testUuid1.toString() + "=" + parserForFileCheck.toString(pronouns1);
+        String expectedLine2 = testUuid2.toString() + "=" + parserForFileCheck.toString(pronouns2);
+
+        assertTrue(lines.stream().anyMatch(line -> line.replace("\\","").equals(expectedLine1)), "Expected line for UUID1 not found or incorrect: " + expectedLine1);
+        assertTrue(lines.stream().anyMatch(line -> line.replace("\\","").equals(expectedLine2)), "Expected line for UUID2 not found or incorrect: " + expectedLine2);
+        assertEquals(2, lines.size(), "File should contain exactly two data lines.");
+    }
+
+
+    @Test
+    @DisplayName("Overwriting pronouns")
+    void overwritePronouns() {
+        store.set(testUuid1, List.of(HE));
+        waitForSave();
+        List<PronounSet> newPronouns = List.of(THEY, SHE);
+        store.set(testUuid1, newPronouns);
+        waitForSave();
+
+        FilePronounStore newStore = new FilePronounStore(mockPlugin, tempDir);
+        assertIterableEquals(newPronouns, newStore.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Setting empty list removes player (results in UNSET_LIST on get)")
+    void setEmptyList() {
+        store.set(testUuid1, List.of(HE));
+        waitForSave();
+        store.set(testUuid1, Collections.emptyList());
+        waitForSave();
+
+        assertEquals(UNSET_LIST, store.sets(testUuid1)); // Check current instance
+        FilePronounStore newStore = new FilePronounStore(mockPlugin, tempDir); // Check persisted
+        assertEquals(UNSET_LIST, newStore.sets(testUuid1));
+    }
+
+    @Nested
+    @DisplayName("addPronouns tests")
+    class AddPronounsTests {
+        @Test
+        @DisplayName("Add to existing single pronoun")
+        void addToExisting() {
+            store.set(testUuid1, List.of(SHE));
+            waitForSave();
+            store.addPronouns(testUuid1, List.of(THEY));
+            waitForSave();
+
+            List<PronounSet> expected = List.of(SHE, THEY);
+            assertIterableEquals(expected, store.sets(testUuid1));
+            FilePronounStore newStore = new FilePronounStore(mockPlugin, tempDir);
+            assertIterableEquals(expected, newStore.sets(testUuid1));
+        }
+
+        // Other addPronoun tests similar to InMemory, ensuring waitForSave and recreation for persistence checks
+    }
+
+    @Nested
+    @DisplayName("removePronouns tests")
+    class RemovePronounsTests {
+        @Test
+        @DisplayName("Remove from existing pronouns")
+        void removeFromExisting() {
+            store.set(testUuid1, List.of(SHE, THEY, HE));
+            waitForSave();
+            store.removePronouns(testUuid1, List.of(THEY));
+            waitForSave();
+
+            List<PronounSet> expected = List.of(SHE, HE);
+            assertIterableEquals(expected, store.sets(testUuid1));
+            FilePronounStore newStore = new FilePronounStore(mockPlugin, tempDir);
+            assertIterableEquals(expected, newStore.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Remove all pronouns (results in UNSET_LIST)")
+        void removeAllPronouns() {
+            List<PronounSet> initialPronouns = List.of(SHE, HE);
+            store.set(testUuid1, initialPronouns);
+            waitForSave();
+            store.removePronouns(testUuid1, new ArrayList<>(initialPronouns));
+            waitForSave();
+
+            assertEquals(UNSET_LIST, store.sets(testUuid1));
+            FilePronounStore newStore = new FilePronounStore(mockPlugin, tempDir);
+            assertEquals(UNSET_LIST, newStore.sets(testUuid1));
+        }
+    }
+
+    // Note: Most behavioral tests for add/remove (edge cases, UNSET handling)
+    // are identical to InMemoryPronounStore once basic persistence of these operations is confirmed.
+    // For brevity, not all minor variations are re-tested with persistence checks
+    // if the core add/remove mechanism is shown to persist.
+
+    @Test
+    @DisplayName("dump() provides current data (FilePronounStore doesn't modify map directly for unmodifiability)")
+    void dumpReturnsCorrectData() {
+        // Dump for FilePronounStore returns a copy of its internal map.
+        store.set(testUuid1, List.of(HE, THEY));
+        store.set(testUuid2, List.of(SHE));
+        // No need to save for dump, it reflects current memory state.
+
+        var dumpedMap = store.dump();
+        assertEquals(2, dumpedMap.size());
+        assertIterableEquals(List.of(HE, THEY), dumpedMap.get(testUuid1));
+        assertIterableEquals(List.of(SHE), dumpedMap.get(testUuid2));
+    }
+}

--- a/pronouns-common/src/test/java/net/lucypoulton/pronouns/common/store/InMemoryPronounStoreTest.java
+++ b/pronouns-common/src/test/java/net/lucypoulton/pronouns/common/store/InMemoryPronounStoreTest.java
@@ -1,0 +1,255 @@
+package net.lucypoulton.pronouns.common.store;
+
+import net.lucypoulton.pronouns.api.PronounStore;
+import net.lucypoulton.pronouns.api.set.PronounSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+public class InMemoryPronounStoreTest {
+
+    private InMemoryPronounStore store;
+    private final UUID testUuid1 = UUID.randomUUID();
+    private final UUID testUuid2 = UUID.randomUUID();
+
+    private final PronounSet HE = PronounSet.Builtins.HE;
+    private final PronounSet SHE = PronounSet.Builtins.SHE;
+    private final PronounSet THEY = PronounSet.Builtins.THEY;
+    private final PronounSet UNSET = PronounSet.Builtins.UNSET; // Convenience
+    private final List<PronounSet> UNSET_LIST = PronounStore.UNSET_LIST;
+
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryPronounStore();
+    }
+
+    @Test
+    @DisplayName("New store returns UNSET_LIST for unknown UUID")
+    void newStoreReturnsUnset() {
+        assertEquals(UNSET_LIST, store.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Set and get a single pronoun set")
+    void setAndGetSinglePronoun() {
+        List<PronounSet> pronouns = List.of(SHE);
+        store.set(testUuid1, pronouns);
+        assertEquals(pronouns, store.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Set and get multiple pronoun sets")
+    void setAndGetMultiplePronouns() {
+        List<PronounSet> pronouns = List.of(SHE, THEY);
+        store.set(testUuid1, pronouns);
+        assertIterableEquals(pronouns, store.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Set pronouns for multiple players")
+    void setAndGetMultiplePlayers() {
+        List<PronounSet> pronouns1 = List.of(SHE, THEY);
+        List<PronounSet> pronouns2 = List.of(HE);
+        store.set(testUuid1, pronouns1);
+        store.set(testUuid2, pronouns2);
+        assertIterableEquals(pronouns1, store.sets(testUuid1));
+        assertIterableEquals(pronouns2, store.sets(testUuid2));
+    }
+
+    @Test
+    @DisplayName("Overwriting pronouns")
+    void overwritePronouns() {
+        store.set(testUuid1, List.of(HE));
+        List<PronounSet> newPronouns = List.of(THEY, SHE);
+        store.set(testUuid1, newPronouns);
+        assertIterableEquals(newPronouns, store.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Setting empty list removes player (should result in UNSET_LIST on get)")
+    void setEmptyList() {
+        store.set(testUuid1, List.of(HE)); // ensure player exists
+        store.set(testUuid1, Collections.emptyList());
+        // InMemoryPronounStore specific: removes player if list is empty, so get should return default
+        assertEquals(UNSET_LIST, store.sets(testUuid1));
+    }
+
+    @Test
+    @DisplayName("Setting UNSET_LIST clears pronouns")
+    void setUnsetList() {
+        store.set(testUuid1, List.of(HE));
+        store.set(testUuid1, UNSET_LIST); // UNSET_LIST is List.of(PronounSet.Builtins.UNSET)
+        // The behavior of setting UNSET_LIST might mean it stores UNSET_LIST or it clears to default UNSET_LIST
+        // For InMemory, set(uuid, List.of(UNSET)) will store that list.
+        assertEquals(UNSET_LIST, store.sets(testUuid1));
+    }
+
+
+    @Nested
+    @DisplayName("addPronouns tests")
+    class AddPronounsTests {
+        @Test
+        @DisplayName("Add to existing single pronoun")
+        void addToExisting() {
+            store.set(testUuid1, List.of(SHE));
+            store.addPronouns(testUuid1, List.of(THEY));
+            assertIterableEquals(List.of(SHE, THEY), store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Add to existing multiple pronouns")
+        void addToExistingMultiple() {
+            store.set(testUuid1, List.of(SHE, HE));
+            store.addPronouns(testUuid1, List.of(THEY));
+            // Order might vary depending on underlying list and add logic, use containsAll for safety
+            List<PronounSet> expected = List.of(SHE, HE, THEY);
+            List<PronounSet> actual = store.sets(testUuid1);
+            assertTrue(actual.containsAll(expected) && expected.containsAll(actual) && actual.size() == expected.size());
+        }
+
+        @Test
+        @DisplayName("Add to unset player")
+        void addToUnsetPlayer() {
+            store.addPronouns(testUuid1, List.of(THEY));
+            assertIterableEquals(List.of(THEY), store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Add existing pronoun (uniqueness)")
+        void addExistingPronoun() {
+            store.set(testUuid1, List.of(SHE, THEY));
+            store.addPronouns(testUuid1, List.of(SHE)); // Adding SHE again
+            assertIterableEquals(List.of(SHE, THEY), store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Add empty list (should do nothing)")
+        void addEmptyList() {
+            store.set(testUuid1, List.of(SHE));
+            store.addPronouns(testUuid1, Collections.emptyList());
+            assertIterableEquals(List.of(SHE), store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Add UNSET to existing pronouns (should replace with UNSET if UNSET is not already primary)")
+        void addUnsetToExisting() {
+            // InMemoryPronounStore specific logic for addPronouns: if current is UNSET, it clears before adding.
+            // If adding UNSET to non-UNSET, it should add UNSET to the list.
+            // However, if the list has UNSET as only item, it's UNSET_LIST.
+            // The implementation of addPronouns in InMemoryPronounStore clears currentSets if it was UNSET.
+            // If currentSets was not UNSET, and we add UNSET, it gets added.
+            // Let's test the case where current is SHE, and we add UNSET.
+            store.set(testUuid1, List.of(SHE));
+            store.addPronouns(testUuid1, List.of(UNSET));
+            // Expected: [SHE, UNSET]
+            List<PronounSet> expected = List.of(SHE, UNSET);
+            List<PronounSet> actual = store.sets(testUuid1);
+            assertTrue(actual.containsAll(expected) && expected.containsAll(actual) && actual.size() == expected.size());
+        }
+
+        @Test
+        @DisplayName("Add pronouns to player who is explicitly UNSET (should replace UNSET)")
+        void addPronounsToExplicitlyUnset() {
+            store.set(testUuid1, UNSET_LIST); // Player is explicitly UNSET
+            store.addPronouns(testUuid1, List.of(HE));
+            assertIterableEquals(List.of(HE), store.sets(testUuid1));
+        }
+    }
+
+    @Nested
+    @DisplayName("removePronouns tests")
+    class RemovePronounsTests {
+        @Test
+        @DisplayName("Remove from existing pronouns")
+        void removeFromExisting() {
+            store.set(testUuid1, List.of(SHE, THEY, HE));
+            store.removePronouns(testUuid1, List.of(THEY));
+            assertIterableEquals(List.of(SHE, HE), store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Remove multiple pronouns")
+        void removeMultiplePronouns() {
+            store.set(testUuid1, List.of(SHE, THEY, HE));
+            store.removePronouns(testUuid1, List.of(SHE, HE));
+            assertIterableEquals(List.of(THEY), store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Remove pronoun not present")
+        void removePronounNotPresent() {
+            store.set(testUuid1, List.of(SHE, HE));
+            store.removePronouns(testUuid1, List.of(THEY)); // THEY is not there
+            assertIterableEquals(List.of(SHE, HE), store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Remove all pronouns (results in UNSET_LIST)")
+        void removeAllPronouns() {
+            List<PronounSet> initialPronouns = List.of(SHE, HE);
+            store.set(testUuid1, initialPronouns);
+            store.removePronouns(testUuid1, new ArrayList<>(initialPronouns)); // Pass a mutable copy
+            assertEquals(UNSET_LIST, store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Remove from unset player (should do nothing)")
+        void removeFromUnsetPlayer() {
+            store.removePronouns(testUuid1, List.of(THEY));
+            assertEquals(UNSET_LIST, store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Remove empty list (should do nothing)")
+        void removeEmptyList() {
+            store.set(testUuid1, List.of(SHE));
+            store.removePronouns(testUuid1, Collections.emptyList());
+            assertIterableEquals(List.of(SHE), store.sets(testUuid1));
+        }
+
+        @Test
+        @DisplayName("Remove UNSET from explicitly UNSET player (results in UNSET_LIST via empty)")
+        void removeUnsetFromUnsetPlayer() {
+            store.set(testUuid1, UNSET_LIST);
+            store.removePronouns(testUuid1, List.of(UNSET)); // or UNSET_LIST
+            assertEquals(UNSET_LIST, store.sets(testUuid1));
+        }
+    }
+
+    @Test
+    @DisplayName("dump() returns an unmodifiable map containing current state")
+    void dumpReturnsCorrectData() {
+        store.set(testUuid1, List.of(HE, THEY));
+        store.set(testUuid2, List.of(SHE));
+
+        var dumpedMap = store.dump();
+        assertEquals(2, dumpedMap.size());
+        assertIterableEquals(List.of(HE, THEY), dumpedMap.get(testUuid1));
+        assertIterableEquals(List.of(SHE), dumpedMap.get(testUuid2));
+
+        // Check if unmodifiable
+        try {
+            dumpedMap.put(UUID.randomUUID(), List.of(UNSET));
+            throw new AssertionError("dump() map should be unmodifiable");
+        } catch (UnsupportedOperationException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    @DisplayName("predefined() returns PronounSet.builtins")
+    void predefinedReturnsBuiltins() {
+        assertEquals(PronounSet.builtins, store.predefined());
+    }
+}

--- a/pronouns-core/src/main/java/net/lucypoulton/pronouns/api/PronounParser.java
+++ b/pronouns-core/src/main/java/net/lucypoulton/pronouns/api/PronounParser.java
@@ -1,53 +1,127 @@
 package net.lucypoulton.pronouns.api;
 
 import net.lucypoulton.pronouns.api.set.PronounSet;
+import net.lucypoulton.pronouns.api.set.SpecialPronounSet;
 import net.lucypoulton.pronouns.api.supplier.PronounSupplier;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+// It might be useful to have a logger, but for now, unparseable parts will be silently ignored or return empty.
+// import java.util.logging.Logger;
 
 public class PronounParser {
-	private final PronounSupplier store;
+    // private static final Logger LOGGER = Logger.getLogger(PronounParser.class.getName());
+	private final PronounSupplier predefinedSupplier;
 
-	public PronounParser(final PronounSupplier store) {
-		this.store = store;
+	public PronounParser(final PronounSupplier predefinedSupplier) {
+		this.predefinedSupplier = predefinedSupplier;
 	}
 
-	public List<PronounSet> parse(String input) {
-		final var split = input.split("[/ ]");
-		final var out = new LinkedHashSet<PronounSet>();
-		final var predefined = store.get();
-		var queuePoint = 0;
-		for (int i = 0; i < split.length; i++) {
-			final var k = split[i];
-			final var matchingSet = predefined.stream().filter(set -> set.includesPronoun(k)).findFirst();
-			if (matchingSet.isPresent()) {
-				queuePoint = i;
-				out.add(matchingSet.get());
+	public @NotNull List<PronounSet> parse(@NotNull String input) {
+		if (input.trim().isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		final List<PronounSet> parsedSets = new ArrayList<>();
+		final String[] parts = input.split(";");
+		final List<PronounSet> predefinedSets = predefinedSupplier.get();
+
+		for (String part : parts) {
+			String trimmedPart = part.trim();
+			if (trimmedPart.isEmpty()) {
 				continue;
 			}
-			if (i - queuePoint == 4){
-				final var last = split[queuePoint+4];
-				final var isPlural = last.endsWith(":p");
-				out.add(PronounSet.from(
-						split[queuePoint],
-						split[queuePoint+1],
-						split[queuePoint+2],
-						split[queuePoint+3],
-						isPlural ? last.substring(0,last.length()-2) : last,
-						isPlural
-				));
+
+			Optional<PronounSet> foundSet = Optional.empty();
+
+            // 1. Check for exact match with predefinedSet.toString() (e.g. "He/Him", "Any")
+            // or predefinedSet.toFullString() (e.g. "he/him/his/his/himself")
+            // or predefinedSet.subjective() (e.g. "he")
+            for (PronounSet predef : predefinedSets) {
+                if (predef.toString().equalsIgnoreCase(trimmedPart) ||
+                    predef.toFullString().equalsIgnoreCase(trimmedPart) ||
+                    predef.subjective().equalsIgnoreCase(trimmedPart)) {
+                    foundSet = Optional.of(predef);
+                    break;
+                }
+                // For SpecialPronounSet, toString is usually the main identifier (e.g., "Any")
+                // For other sets, also check simple subjective if not already caught by above
+                 if (!(predef instanceof SpecialPronounSet) && predef.subjective().equalsIgnoreCase(trimmedPart)) {
+                    foundSet = Optional.of(predef);
+                    break;
+                }
+            }
+
+			if (foundSet.isPresent()) {
+				parsedSets.add(foundSet.get());
+				continue;
 			}
+
+			// 2. Try parsing as custom s/o/pa/p/r(:p)
+			// This regex ensures 5 parts, with the last optionally having :p
+            // String[] customParts = trimmedPart.split("/"); // Original
+            // More robust splitting that doesn't create empty strings if input is like "a//b"
+            String[] customParts = trimmedPart.split("/", -1);
+
+
+			if (customParts.length == 5) {
+				try {
+					String subjective = customParts[0].trim();
+					String objective = customParts[1].trim();
+					String possessiveAdj = customParts[2].trim();
+					String possessive = customParts[3].trim();
+					String reflexivePart = customParts[4].trim();
+					boolean isPlural = false;
+
+					if (reflexivePart.toLowerCase().endsWith(":p")) {
+						isPlural = true;
+						reflexivePart = reflexivePart.substring(0, reflexivePart.length() - 2).trim();
+					}
+
+					if (subjective.isEmpty() || objective.isEmpty() || possessiveAdj.isEmpty() || possessive.isEmpty() || reflexivePart.isEmpty()) {
+                        // LOGGER.warning("Skipping malformed custom pronoun part (empty components): " + trimmedPart);
+						continue;
+					}
+                    // Ensure that a custom definition doesn't accidentally match a predefined one's partial forms
+                    // e.g. custom "any/else/goes/here/now" shouldn't be parsed if "any" was meant for Builtins.ANY
+                    // This is implicitly handled because predefined check is done first.
+					parsedSets.add(PronounSet.from(subjective, objective, possessiveAdj, possessive, reflexivePart, isPlural));
+				} catch (Exception e) {
+                    // LOGGER.warning("Failed to parse custom pronoun part: " + trimmedPart + " due to " + e.getMessage());
+				}
+				continue; // whether successful or failed custom parse, move to next part
+			}
+
+            // 3. If not custom format, and not already matched, check if the trimmedPart (single token)
+            // matches any form of a predefined set (e.g. "him", "herself")
+            // This is for cases like "she;him"
+            if (!trimmedPart.contains("/")) { // Only if it's a single word
+                for (PronounSet predef : predefinedSets) {
+                    if (predef.includesPronoun(trimmedPart)) {
+                        foundSet = Optional.of(predef);
+                        break;
+                    }
+                }
+                if (foundSet.isPresent()) {
+                    parsedSets.add(foundSet.get());
+                    continue;
+                }
+            }
+            // If we reach here, the part is unparseable
+            // LOGGER.info("Skipping unparseable pronoun part: " + trimmedPart);
 		}
-		if (out.isEmpty()) throw new IllegalArgumentException("Failed to parse " + input);
-		return List.copyOf(out);
+        // Return a list with unique pronouns, preserving order of first appearance
+		return List.copyOf(new LinkedHashSet<>(parsedSets));
 	}
 
-	public String toString(List<PronounSet> pronounSets) {
-		final var predefined = store.get();
+	public String toString(@NotNull List<PronounSet> pronounSets) {
 		return pronounSets.stream()
-				.map(set -> predefined.contains(set) ? set.subjective() : set.toFullString())
-				.collect(Collectors.joining("/"));
+				.map(PronounSet::toFullString)
+				.collect(Collectors.joining(";"));
 	}
 }

--- a/pronouns-core/src/main/java/net/lucypoulton/pronouns/api/PronounStore.java
+++ b/pronouns-core/src/main/java/net/lucypoulton/pronouns/api/PronounStore.java
@@ -44,6 +44,22 @@ public interface PronounStore {
     void setAll(Map<UUID, List<PronounSet>> sets);
 
     /**
+     * Adds to a player's existing pronouns.
+     *
+     * @param player         the player's UUID
+     * @param pronounsToAdd the pronouns to add. Each entry must be unique.
+     */
+    void addPronouns(UUID player, @NotNull List<PronounSet> pronounsToAdd);
+
+    /**
+     * Removes specific pronouns from a player's set pronouns.
+     *
+     * @param player            the player's UUID
+     * @param pronounsToRemove the pronouns to remove.
+     */
+    void removePronouns(UUID player, @NotNull List<PronounSet> pronounsToRemove);
+
+    /**
      * Gets a (possibly unmodifiable) map of every player and the pronouns they have set. This method may block.
      */
     Map<UUID, List<PronounSet>> dump();

--- a/pronouns-core/src/main/java/net/lucypoulton/pronouns/api/set/PronounSet.java
+++ b/pronouns-core/src/main/java/net/lucypoulton/pronouns/api/set/PronounSet.java
@@ -140,13 +140,18 @@ public interface PronounSet {
      * @param sets a list of pronoun sets, containing at least one element.
      */
     static String format(List<PronounSet> sets) {
+        if (sets == null || sets.isEmpty()) {
+            // Or return a default string like "Unset" or an empty string,
+            // depending on desired behavior for empty/null lists.
+            // Throwing an exception is also an option if formatting an empty list is considered an error.
+            // For now, let's match the previous behavior of throwing for 0, but also handle null.
+            throw new IllegalArgumentException("A list of 0 pronouns, or a null list, cannot be formatted");
+        }
         return switch (sets.size()) {
-            case 0 -> throw new IllegalArgumentException("A list of 0 pronouns cannot be formatted");
             case 1 -> sets.get(0).toString();
             default -> sets.stream()
-                            .map(set -> set instanceof SpecialPronounSet ? set.toString() : set.subjective())
-                            .map(StringUtils::capitalize)
-                            .collect(Collectors.joining("/"));
+                            .map(PronounSet::toString) // Use the PronounSet's own toString()
+                            .collect(Collectors.joining(", ")); // Join with ", "
         };
     }
 }

--- a/pronouns-core/src/test/java/net/lucypoulton/pronouns/api/test/ParserTests.java
+++ b/pronouns-core/src/test/java/net/lucypoulton/pronouns/api/test/ParserTests.java
@@ -2,68 +2,258 @@ package net.lucypoulton.pronouns.api.test;
 
 import net.lucypoulton.pronouns.api.PronounParser;
 import net.lucypoulton.pronouns.api.set.PronounSet;
+import net.lucypoulton.pronouns.api.set.SimplePronounSet;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
 
 public class ParserTests {
 
-    private final PronounSet[] sets = {
+    // Existing parser with custom sets for some specific tests
+    private final PronounSet[] customTestSets = {
             PronounSet.from("one", "two", "three", "four", "five", false),
             PronounSet.from("six", "seven", "eight", "nine", "ten", false)
     };
+    private final PronounParser customParser = new PronounParser(() -> Set.of(customTestSets));
 
-    private final PronounParser parser = new PronounParser(() -> Set.of(sets));
+    // New parser using PronounSet.builtins for most tests
+    private final PronounParser parser = new PronounParser(PronounSet.builtins);
 
     @Test
-    @DisplayName("Parses predefined sets")
-    void parsesPredefined() {
+    @DisplayName("Legacy: Parses predefined parts (custom sets)")
+    void parsesPredefined_legacy() {
         for (final var part : List.of("one", "two", "three", "four", "five"))
-            assertEquals(parser.parse(part).get(0), sets[0]);
-    }
-
-    @ParameterizedTest
-    @DisplayName("Parses multiple predefined sets")
-    @ValueSource(strings = {"one/six", "two/seven", "three/eight", "four/nine", "five/ten"})
-    void parsesMultiple(final String input) {
-        final var parsed = parser.parse(input);
-        assertEquals(parsed.get(0), sets[0]);
-        assertEquals(parsed.get(1), sets[1]);
+            assertEquals(customTestSets[0], customParser.parse(part).get(0));
     }
 
     @Test
-    @DisplayName("Excludes repeated predefined sets")
-    void excludesRepeated() {
-        final var set = parser.parse("one/two/one/two/one");
-        assertEquals(set.size(), 1);
-        assertEquals(set.get(0), sets[0]);
+    @DisplayName("Legacy: Parses multiple predefined sets with semicolon (custom sets)")
+    void parsesMultiple_legacy() {
+        // This test is updated to use semicolon, matching current parser logic
+        final var parsed = customParser.parse("one;six");
+        assertEquals(2, parsed.size());
+        assertIterableEquals(List.of(customTestSets[0], customTestSets[1]), parsed);
     }
 
     @Test
-    @DisplayName("Parses non-predefined singular sets")
-    void parsesSingular() {
+    @DisplayName("Legacy: Excludes repeated predefined sets (custom sets)")
+    void excludesRepeated_legacy() {
+        final var set = customParser.parse("one;two;one;two;one");
+        assertEquals(1, set.size());
+        assertEquals(customTestSets[0], set.get(0));
+    }
+
+    @Test
+    @DisplayName("Legacy: Parses non-predefined singular sets (custom parser context)")
+    void parsesSingular_legacy() {
         final var set = PronounSet.from("a", "b", "c", "d", "e", false);
-        assertEquals(parser.parse("a/b/c/d/e").get(0), set);
+        // Using customParser to ensure it can parse custom sets not in its predefined list
+        assertEquals(set, customParser.parse("a/b/c/d/e").get(0));
     }
 
     @Test
-    @DisplayName("Parses non-predefined plural sets")
-    void parsesPlural() {
+    @DisplayName("Legacy: Parses non-predefined plural sets (custom parser context)")
+    void parsesPlural_legacy() {
         final var set = PronounSet.from("a", "b", "c", "d", "e", true);
-        assertEquals(parser.parse("a/b/c/d/e:p").get(0), set);
+        assertEquals(set, customParser.parse("a/b/c/d/e:p").get(0));
     }
 
     @ParameterizedTest
-    @DisplayName("Throws when an effectively zero input is given")
-    @ValueSource(strings = {"", "/", " ", " / ", "arbitrary"})
-    void throwsOnEffectivelyZero(String value) {
-        assertThrows(IllegalArgumentException.class, () -> parser.parse(value));
+    @DisplayName("Returns empty list for effectively zero or invalid inputs")
+    @ValueSource(strings = {"", "/", " ", " / ", "arbitraryNonPronounString", "he/him/his/INVALID/himself"})
+    void returnsEmptyListForInvalidInputs(String value) {
+        // Updated: parser now returns empty list instead of throwing
+        assertTrue(parser.parse(value).isEmpty(), "Input: " + value);
+        assertTrue(customParser.parse(value).isEmpty(), "Input with custom parser: " + value);
+    }
+
+    @Test
+    @DisplayName("Returns empty list for multiple empty parts")
+    void returnsEmptyListForMultipleEmptyParts() {
+        assertTrue(parser.parse(";;").isEmpty());
+        assertTrue(parser.parse(" ; ; ").isEmpty());
+    }
+
+    @Nested
+    @DisplayName("Tests with PronounSet.builtins")
+    class BuiltinParserTests {
+
+        @Test
+        @DisplayName("Parses single predefined pronoun: he")
+        void parsesHe() {
+            assertIterableEquals(List.of(PronounSet.Builtins.HE), parser.parse("he"));
+        }
+
+        @Test
+        @DisplayName("Parses single predefined pronoun: she")
+        void parsesShe() {
+            assertIterableEquals(List.of(PronounSet.Builtins.SHE), parser.parse("she"));
+        }
+
+        @Test
+        @DisplayName("Parses single predefined pronoun: they")
+        void parsesThey() {
+            assertIterableEquals(List.of(PronounSet.Builtins.THEY), parser.parse("they"));
+        }
+
+        @Test
+        @DisplayName("Parses single predefined pronoun by full string: he/him/his/his/himself")
+        void parsesHeByFullString() {
+            assertIterableEquals(List.of(PronounSet.Builtins.HE), parser.parse("he/him/his/his/himself"));
+        }
+
+        @Test
+        @DisplayName("Parses single predefined pronoun by short string: He/Him")
+        void parsesHeByShortString() {
+            assertIterableEquals(List.of(PronounSet.Builtins.HE), parser.parse("He/Him"));
+            assertIterableEquals(List.of(PronounSet.Builtins.HE), parser.parse("he/him")); // lowercase
+        }
+
+        @Test
+        @DisplayName("Parses single predefined pronoun by objective form: him")
+        void parsesHim() {
+            assertIterableEquals(List.of(PronounSet.Builtins.HE), parser.parse("him"));
+        }
+
+        @Test
+        @DisplayName("Parses multiple predefined pronouns: he;they")
+        void parsesMultiplePredefined() {
+            List<PronounSet> expected = List.of(PronounSet.Builtins.HE, PronounSet.Builtins.THEY);
+            assertIterableEquals(expected, parser.parse("he;they"));
+        }
+
+        @Test
+        @DisplayName("Parses multiple predefined pronouns with spaces and mixed formats: she ; he/him ")
+        void parsesMultiplePredefinedWithSpacesAndMixedFormats() {
+            List<PronounSet> expected = List.of(PronounSet.Builtins.SHE, PronounSet.Builtins.HE);
+            assertIterableEquals(expected, parser.parse(" she ; he/him "));
+        }
+
+        @Test
+        @DisplayName("Parses single custom pronoun: ze/zir/zir/zirs/zirself")
+        void parsesSingleCustomPronoun() {
+            PronounSet expected = new SimplePronounSet("ze", "zir", "zir", "zirs", "zirself", false);
+            assertIterableEquals(List.of(expected), parser.parse("ze/zir/zir/zirs/zirself"));
+        }
+
+        @Test
+        @DisplayName("Parses single custom pronoun with plural: xe/xem/xyr/xyrs/xemself:p")
+        void parsesSingleCustomPronounPlural() {
+            PronounSet expected = new SimplePronounSet("xe", "xem", "xyr", "xyrs", "xemself", true);
+            assertIterableEquals(List.of(expected), parser.parse("xe/xem/xyr/xyrs/xemself:p"));
+        }
+
+        @Test
+        @DisplayName("Parses custom pronoun with spaces in parts: ze / zir / zir / zirs / zirself")
+        void parsesCustomPronounWithSpacesInParts() {
+            PronounSet expected = new SimplePronounSet("ze", "zir", "zir", "zirs", "zirself", false);
+            assertIterableEquals(List.of(expected), parser.parse("ze / zir / zir / zirs / zirself"));
+        }
+
+
+        @Test
+        @DisplayName("Parses multiple custom pronouns")
+        void parsesMultipleCustomPronouns() {
+            PronounSet custom1 = new SimplePronounSet("ze", "zir", "zir", "zirs", "zirself", false);
+            PronounSet custom2 = new SimplePronounSet("xe", "xem", "xyr", "xyrs", "xemself", true);
+            List<PronounSet> expected = List.of(custom1, custom2);
+            assertIterableEquals(expected, parser.parse("ze/zir/zir/zirs/zirself;xe/xem/xyr/xyrs/xemself:p"));
+        }
+
+        @Test
+        @DisplayName("Parses mixed predefined and custom pronouns: she;ze/zir/zir/zirs/zirself;they")
+        void parsesMixedPredefinedAndCustom() {
+            PronounSet custom = new SimplePronounSet("ze", "zir", "zir", "zirs", "zirself", false);
+            List<PronounSet> expected = List.of(PronounSet.Builtins.SHE, custom, PronounSet.Builtins.THEY);
+            assertIterableEquals(expected, parser.parse("she;ze/zir/zir/zirs/zirself;they"));
+        }
+
+        @Test
+        @DisplayName("Preserves order and ensures uniqueness: he;they;he")
+        void preservesOrderAndEnsuresUniqueness() {
+            List<PronounSet> expected = List.of(PronounSet.Builtins.HE, PronounSet.Builtins.THEY);
+            assertIterableEquals(expected, parser.parse("he;they;he"));
+        }
+
+        @Test
+        @DisplayName("Ignores invalid parts among valid ones: he;invalid;they")
+        void ignoresInvalidPartsAmongValid() {
+            List<PronounSet> expected = List.of(PronounSet.Builtins.HE, PronounSet.Builtins.THEY);
+            assertIterableEquals(expected, parser.parse("he;invalidStringPart;they"));
+        }
+
+        @Test
+        @DisplayName("Ignores malformed custom pronoun parts: he;a/b/c;they")
+        void ignoresMalformedCustomParts() {
+            List<PronounSet> expected = List.of(PronounSet.Builtins.HE, PronounSet.Builtins.THEY);
+            assertIterableEquals(expected, parser.parse("he;a/b/c;they")); // a/b/c is not 5 parts
+        }
+
+
+        @Test
+        @DisplayName("Parses Builtins.ANY")
+        void parsesAny() {
+            assertIterableEquals(List.of(PronounSet.Builtins.ANY), parser.parse("any"));
+        }
+
+        @Test
+        @DisplayName("Parses Builtins.ASK and Builtins.UNSET")
+        void parsesAskAndUnset() {
+            List<PronounSet> expected = List.of(PronounSet.Builtins.ASK, PronounSet.Builtins.UNSET);
+            assertIterableEquals(expected, parser.parse("ask;unset"));
+        }
+
+        @Test
+        @DisplayName("Parses PronounSet.Builtins.THEY.toString()")
+        void parsesPredefinedToString() {
+            assertIterableEquals(List.of(PronounSet.Builtins.THEY), parser.parse(PronounSet.Builtins.THEY.toString()));
+        }
+
+        @Test
+        @DisplayName("Parses PronounSet.Builtins.SHE.toFullString()")
+        void parsesPredefinedToFullString() {
+            assertIterableEquals(List.of(PronounSet.Builtins.SHE), parser.parse(PronounSet.Builtins.SHE.toFullString()));
+        }
+
+        @Test
+        @DisplayName("Parses a mix of full string, short string, and subjective for predefined")
+        void parsesMixedPredefinedFormats() {
+            List<PronounSet> expected = List.of(PronounSet.Builtins.HE, PronounSet.Builtins.SHE, PronounSet.Builtins.THEY);
+            assertIterableEquals(expected, parser.parse("he/him/his/his/himself;She/Her;they"));
+        }
+
+        @Test
+        @DisplayName("Serializes a list of PronounSets correctly")
+        void serializesListToString() {
+            PronounSet customZe = PronounSet.from("ze", "zir", "zir", "zirs", "zirself", false);
+            List<PronounSet> sets = List.of(PronounSet.Builtins.SHE, customZe, PronounSet.Builtins.THEY);
+            String expected = "she/her/her/hers/herself;ze/zir/zir/zirs/zirself;they/them/their/theirs/themselves:p";
+            assertEquals(expected, parser.toString(sets));
+        }
+
+        @Test
+        @DisplayName("Serializes an empty list to an empty string")
+        void serializesEmptyList() {
+            assertEquals("", parser.toString(Collections.emptyList()));
+        }
+
+        @Test
+        @DisplayName("Serializes a list with one set")
+        void serializesSingletonList() {
+            List<PronounSet> sets = List.of(PronounSet.Builtins.HE);
+            String expected = "he/him/his/his/himself";
+            assertEquals(expected, parser.toString(sets));
+        }
     }
 }


### PR DESCRIPTION
…enhancements

This commit introduces several significant enhancements to pronoun handling:

1.  **Multiple Pronoun Sets:**
    - Players can now define and use multiple pronoun sets (e.g., "she/her" and "they/them").
    - `PronounStore` interface and implementations (InMemory, File, MySQL) updated to store `List<PronounSet>`.
    - MySQL schema will require `pronouns` column to be `TEXT` (or similar) to store semicolon-delimited pronoun strings.
    - Commands (`/pronouns set`, `/pronouns get`, `/pronouns clear`) updated to support multiple sets. Players use a semicolon (`;`) to separate sets in the set command.

2.  **Custom Pronoun/Neopronoun Support:**
    - Players can define custom pronoun sets using the format: `subjective/objective/possessiveAdjective/possessivePronoun/reflexive`
    - An optional `:p` suffix can be added for plural conjugation (e.g., `ze/zir/zir/zirs/zirself:p`).
    - `PronounParser` updated to parse these custom strings.

3.  **Enhanced PlaceholderAPI Support:**
    - Placeholders (`%pronouns_subjective%`, `%pronouns_verb_BE%`, etc.) now support an optional 1-based index to select from a player's list of pronoun sets (e.g., `%pronouns_subjective_1%`, `%pronouns_verb_2_BE%`).
    - If no index is provided, placeholders default to the first set.
    - Invalid indices result in an empty string for the placeholder.
    - `%pronouns_all%` now displays all of a player's pronoun sets in their full `toFullString()` format, joined by "; ".
    - `%pronouns_pronouns%` formats the list of sets for display (e.g., "She/Her, They/Them").

4.  **Parsing and Formatting:**
    - `PronounParser` now parses semicolon-delimited strings for multiple sets and handles custom formats. Unparseable parts are ignored.
    - `PronounSet.format(List<PronounSet>)` updated for clearer display of multiple sets.
    - Serialization of `List<PronounSet>` to a semicolon-delimited string of `toFullString()` representations is used for storage.

5.  **Testing and Documentation:**
    - I added extensive unit tests for `PronounParser`.
    - I also added unit tests for `InMemoryPronounStore` and `FilePronounStore`.
    - I updated all relevant documentation (README, command guides, placeholder lists, pronoun format guides) to reflect these new features and usage.

These changes provide significantly more flexibility and inclusivity for players wishing to express their identity through pronouns.