### PR TITLE
Fix: Defer PronounParser initialization to prevent NPE

### DIFF
--- a/pronouns-maven/src/main/java/net/lucypoulton/pronouns/common/ProNouns.java
+++ b/pronouns-maven/src/main/java/net/lucypoulton/pronouns/common/ProNouns.java
@@ -27,7 +27,7 @@ public class ProNouns implements ProNounsPlugin {
         thread.setName("ProNouns worker");
         return thread;
     });
-    private final PronounParser parser;
+    private PronounParser parser;
     private final Platform platform;
     private final PluginMeta meta;
     private final Placeholders placeholders = new Placeholders(this);
@@ -39,7 +39,6 @@ public class ProNouns implements ProNounsPlugin {
     public ProNouns(Platform platform) {
         this.platform = platform;
         this.formatter = new Formatter(platform);
-        this.parser = new PronounParser(() -> store.predefined().get());
         this.meta = new PluginMeta(platform);
 
         platform.logger().info(meta.identifier());
@@ -103,6 +102,7 @@ public class ProNouns implements ProNounsPlugin {
 
     public void createStore(StoreFactory factory) {
         this.store = factory.create(platform.config().store().toLowerCase(Locale.ROOT).trim(), this);
+        this.parser = new PronounParser(() -> store.predefined().get());
     }
 
     public void reload() {


### PR DESCRIPTION
The PronounParser was being initialized in the ProNouns constructor. However, the PronounParser depends on the PronounStore (via a lambda supplier) which was only initialized later in the createStore() method, after the ProNouns constructor had completed.

This resulted in a NullPointerException when the PronounParser attempted to access the null PronounStore during its own construction.

This commit defers the PronounParser initialization until after the PronounStore has been initialized within the createStore() method, ensuring the store is available when the parser needs it.